### PR TITLE
Fixed findTaskFile so TaskCmd works with node v0.10

### DIFF
--- a/bin/lib/taskIO.js
+++ b/bin/lib/taskIO.js
@@ -34,6 +34,8 @@ module.exports.saveTasks = function (tasks) {
 
 // Traverse up the directory tree looking for a .tasks.json file
 module.exports.findTaskFile = function (path, prev) {
+   if (prev === undefined)  { prev = ''; }
+
    if (filePath.join(path) == filePath.join(prev)) {
       feedback.message('No task file found.');
       return cwd;


### PR DESCRIPTION
path.join need a string argument since node v0.10.0 and an exception is
thrown otherwise
